### PR TITLE
Allow creating new Builders using BaseRecordBuilder

### DIFF
--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/BaseRecordBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/BaseRecordBuilder.java
@@ -85,7 +85,7 @@ public abstract class BaseRecordBuilder implements RecordBuilder {
      * 
      * @throws JMSException      Message could not be converted
      */
-    SchemaAndValue getKey(JMSContext context, String topic, Message message) throws JMSException {
+    public SchemaAndValue getKey(JMSContext context, String topic, Message message) throws JMSException {
         Schema keySchema = null;
         Object key = null;
         String keystr;
@@ -134,7 +134,7 @@ public abstract class BaseRecordBuilder implements RecordBuilder {
      * 
      * @throws JMSException      Message could not be converted
      */
-    abstract SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException;
+    public abstract SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException;
 
    /**
      * Convert a message into a Kafka Connect SourceRecord.

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/DefaultRecordBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/DefaultRecordBuilder.java
@@ -55,7 +55,7 @@ public class DefaultRecordBuilder extends BaseRecordBuilder {
      * 
      * @throws JMSException      Message could not be converted
      */
-    @Override SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException {
+    @Override public SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException {
         Schema valueSchema = null;
         Object value = null;
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/JsonRecordBuilder.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/builders/JsonRecordBuilder.java
@@ -64,7 +64,7 @@ public class JsonRecordBuilder extends BaseRecordBuilder {
      * 
      * @throws JMSException      Message could not be converted
      */
-    @Override SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException {
+    @Override public SchemaAndValue getValue(JMSContext context, String topic, boolean messageBodyJms, Message message) throws JMSException {
         byte[] payload;
 
         if (message instanceof BytesMessage) {


### PR DESCRIPTION
The current `BaseRecordBuilder` interface defines some abstract methods,
without declaring their visibility.

This means it is by default, they are `package-private`, and we can't
create sub-classes extending the behaviour.

One scenario where extanding from another package is ideal would be when
extra headers are required to be sent to Kafka. This commit changes the
modifier to be public so others could extend them.