### PR TITLE
Exposes MQMD headers to Record Builders

### DIFF
--- a/config/mq-source.properties
+++ b/config/mq-source.properties
@@ -55,6 +55,9 @@ mq.record.builder=com.ibm.eventstreams.connect.mqsource.builders.DefaultRecordBu
 # Whether to interpret the message body as a JMS message type (default false) - optional
 # mq.message.body.jms=
 
+# Whether to expose MQMD headers (default false) - optional
+# mq.message.headers.mqmd=false
+
 # The JMS message header to use as the Kafka record key - optional
 # Valid values are JMSMessageID, JMSCorrelationID and JMSCorrelationIDAsBytes
 # Don't forget to set key.converter to a compatible converter as described in README.md

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/JMSReader.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/JMSReader.java
@@ -93,6 +93,7 @@ public class JMSReader {
         String ccdtUrl = props.get(MQSourceConnector.CONFIG_NAME_MQ_CCDT_URL);
         String builderClass = props.get(MQSourceConnector.CONFIG_NAME_MQ_RECORD_BUILDER);
         String mbj = props.get(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_BODY_JMS);
+        String mqmdHeaders = props.get(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_HEADERS_MQMD);
         String sslCipherSuite = props.get(MQSourceConnector.CONFIG_NAME_MQ_SSL_CIPHER_SUITE);
         String sslPeerName = props.get(MQSourceConnector.CONFIG_NAME_MQ_SSL_PEER_NAME);
         String topic = props.get(MQSourceConnector.CONFIG_NAME_TOPIC);
@@ -154,6 +155,12 @@ public class JMSReader {
                 if (Boolean.parseBoolean(mbj)) {
                     this.messageBodyJms = true;
                     queue.setMessageBodyStyle(WMQConstants.WMQ_MESSAGE_BODY_JMS);
+                }
+            }
+
+            if (mqmdHeaders != null) {
+                if (Boolean.parseBoolean(mqmdHeaders)) {
+                    queue.setBooleanProperty(WMQConstants.WMQ_MQMD_READ_ENABLED, true);
                 }
             }
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
@@ -77,6 +77,10 @@ public class MQSourceConnector extends SourceConnector {
     public static final String CONFIG_DOCUMENTATION_MQ_MESSAGE_BODY_JMS = "Whether to interpret the message body as a JMS message type.";
     public static final String CONFIG_DISPLAY_MQ_MESSAGE_BODY_JMS = "Message body as JMS";
 
+    public static final String CONFIG_NAME_MQ_MESSAGE_HEADERS_MQMD = "mq.message.headers.mqmd";
+    public static final String CONFIG_DOCUMENTATION_MQ_MESSAGE_HEADERS_MQMD = "Whether to expose MQMD headers on the message object.";
+    public static final String CONFIG_DISPLAY_MQ_MESSAGE_HEADERS_MQMD = "Enable MQMD headers";
+
     public static final String CONFIG_NAME_MQ_RECORD_BUILDER_KEY_HEADER = "mq.record.builder.key.header";
     public static final String CONFIG_DOCUMENTATION_MQ_RECORD_BUILDER_KEY_HEADER = "The JMS message header to use as the Kafka record key.";
     public static final String CONFIG_DISPLAY_MQ_RECORD_BUILDER_KEY_HEADER = "Record builder key header";
@@ -239,6 +243,10 @@ public class MQSourceConnector extends SourceConnector {
                       ConfigDef.Range.atLeast(CONFIG_VALUE_MQ_BATCH_SIZE_MINIMUM), Importance.LOW,
                       CONFIG_DOCUMENTATION_MQ_BATCH_SIZE, CONFIG_GROUP_MQ, 14, Width.MEDIUM,
                       CONFIG_DISPLAY_MQ_BATCH_SIZE);
+
+        config.define(CONFIG_NAME_MQ_MESSAGE_HEADERS_MQMD, Type.BOOLEAN, Boolean.FALSE, Importance.MEDIUM,
+                CONFIG_DOCUMENTATION_MQ_MESSAGE_HEADERS_MQMD, CONFIG_GROUP_MQ, 15, Width.SHORT,
+                CONFIG_DISPLAY_MQ_MESSAGE_HEADERS_MQMD);
 
         config.define(CONFIG_NAME_TOPIC, Type.STRING, null, Importance.HIGH,
                       CONFIG_DOCUMENTATION_TOPIC, null, 0, Width.MEDIUM,


### PR DESCRIPTION
We have some requirements on our application to read some MQMD headers.

When creating a new Record Builder to read MQ messages, the headers are
not exposed as is. To access, for example, the
`JMS_IBM_MQMD_ApplIdentityData` field, we would need to set the
`WMQ_MQMD_READ_ENABLED` field on the queue object.

> [...] you can extract the contents of the MQMD fields by setting
> WMQ_MQMD_READ_ENABLED to true before receiving a message and then using
> the get methods of the message, such as getStringProperty.

Source: https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.dev.doc/q032330_.htm

This code includes an extra configuration option on the task level,
where we could change the queue attribute to expose MQMD headers to the
message object used on Record Builders.

I accept the CLA