### PR TITLE
Could com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1 drop off redundant dependencies to loose weight?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,20 @@
       <artifactId>connect-json</artifactId>
       <version>2.6.0</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
+          <artifactId>jackson-datatype-jdk8</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -64,6 +78,20 @@
       <groupId>com.ibm.mq</groupId>
       <artifactId>com.ibm.mq.allclient</artifactId>
       <version>9.1.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>  
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
@slachiewicz Hi, I am a user of project **_com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1_**. I found that its pom file introduced **_26_** dependencies. However, among them, **_7_** libraries (**_26%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.json:json:jar:20080701:compile
org.bouncycastle:bcprov-jdk15on:jar:1.64:compile
com.fasterxml.jackson.core:jackson-core:jar:2.10.2:provided
org.bouncycastle:bcpkix-jdk15on:jar:1.64:compile
com.fasterxml.jackson.core:jackson-annotations:jar:2.10.2:provided
com.fasterxml.jackson.core:jackson-databind:jar:2.10.2:provided
com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.10.2:provided
</code></pre>