### PR TITLE
Could com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1 drop off redundant dependencies? 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,20 @@
       <groupId>com.ibm.mq</groupId>
       <artifactId>com.ibm.mq.allclient</artifactId>
       <version>9.1.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>org.bouncycastle</groupId>
+           <artifactId>bcpkix-jdk15on</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>org.json</groupId>
+           <artifactId>json</artifactId>
+         </exclusion>
+       </exclusions>
     </dependency>
 
     <dependency>
@@ -83,6 +97,12 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>byte-buddy-agent</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hi! I found the pom file of project **_com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1_** introduced **_14_** dependencies. However, among them, **_6_** libraries (**_42%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.json:json:jar:20080701:compile
log4j:log4j:jar:1.2.17:test
org.slf4j:slf4j-log4j12:jar:1.7.25:test
net.bytebuddy:byte-buddy-agent:jar:1.9.10:test
org.bouncycastle:bcprov-jdk15on:jar:1.64:compile
org.bouncycastle:bcpkix-jdk15on:jar:1.64:compile
## Vulnerable libraries
log4j:log4j:1.2.17 (CVE-2022-23305)

## Outdated dependencies
net.bytebuddy:byte-buddy-agent:1.9.10 (**_1629_** days without maintenance)
org.slf4j:slf4j-log4j12:1.7.25 (**_2326_** days without maintenance)
org.json:json:20080701 (**_5487_** days without maintenance)
log4j:log4j:1.2.17 (**_4082_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_log4j:log4j:jar:1.2.17:test_** incorporates a critical-level vulnerability SNYK-JAVA-LOG4J-572732. As such, I suggest a refactoring operation for **_com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.ibm.eventstreams.connect:kafka-connect-mq-source:1.3.1_**’s maven tests.

Best regards