### PR TITLE
fix: rollback messages to MQ if they cannot be transformed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=esuser:esgroup --from=builder /opt/kafka/libs/ /opt/kafka/libs/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-distributed.properties /opt/kafka/config/
 COPY --chown=esuser:esgroup --from=builder /opt/kafka/config/connect-log4j.properties /opt/kafka/config/
 RUN mkdir /opt/kafka/logs && chown esuser:esgroup /opt/kafka/logs
-COPY --chown=esuser:esgroup target/kafka-connect-mq-source-1.3.1-jar-with-dependencies.jar /opt/kafka/libs/
+COPY --chown=esuser:esgroup target/kafka-connect-mq-source-1.3.2-jar-with-dependencies.jar /opt/kafka/libs/
 
 WORKDIR /opt/kafka
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>com.ibm.eventstreams.connect</groupId>
   <artifactId>kafka-connect-mq-source</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <name>kafka-connect-mq-source</name>
     <organization>
     <name>IBM Corporation</name>

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
@@ -135,7 +135,7 @@ public class MQSourceConnector extends SourceConnector {
     public static final String CONFIG_DOCUMENTATION_TOPIC = "The name of the target Kafka topic.";
     public static final String CONFIG_DISPLAY_TOPIC = "Target Kafka topic";
 
-    public static String VERSION = "1.3.1";
+    public static String VERSION = "1.3.2";
 
     private Map<String, String> configProps;
 


### PR DESCRIPTION
Some JMS message types cannot be processed by the record builder.
To avoid losing these messages, they should be rolled back to the
MQ queue that they came from.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>