### PR TITLE
fix: update deprecated set-env and update java version.

### DIFF
--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 8
+          distribution: 'temurin'
       - name: Get java-version
         run: |
           BUILD_VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
-          echo "::set-env name=VERSION::$BUILD_VERSION"
+          echo "VERSION=$BUILD_VERSION" >> $GITHUB_ENV
       - name: Build
         run: mvn package
       - name: Create Release
@@ -33,8 +34,8 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
+      - name: Upload Release Asset With Dependencies
+        id: upload-release-asset-with-dependencies
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +43,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./target/kafka-connect-mq-source-${{env.VERSION}}-jar-with-dependencies.jar
           asset_name: kafka-connect-mq-source-${{env.VERSION}}-jar-with-dependencies.jar
+          asset_content_type: application/java-archive
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/kafka-connect-mq-source-${{env.VERSION}}.jar
+          asset_name: kafka-connect-mq-source-${{env.VERSION}}.jar
           asset_content_type: application/java-archive


### PR DESCRIPTION
- Update set-env way to setting environment variables.
- Update java to version 8 distribution temurin
- Add a additional asset kafka-connect-mq-source-VERSION.jar

My last github action run can be considered as an example for this change.
https://github.com/Joel-hanson/kafka-connect-mq-source/actions/runs/4373115674

![image](https://user-images.githubusercontent.com/17215044/223984487-f26689a5-39f6-46f5-932c-6d851d95720e.png)
