### PR TITLE
refactor: delegate config validation to Kafka Connect

### DIFF
--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskAuthIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskAuthIT.java
@@ -72,6 +72,7 @@ public class MQSourceTaskAuthIT {
         connectorProps.put("mq.password", APP_PASSWORD);
         connectorProps.put("mq.message.body.jms", "false");
         connectorProps.put("mq.record.builder", "com.ibm.eventstreams.connect.mqsource.builders.DefaultRecordBuilder");
+        connectorProps.put("topic", "mytopic");
         return connectorProps;
     }
 

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
@@ -61,6 +61,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         props.put("mq.channel.name", getChannelName());
         props.put("mq.queue", MQ_QUEUE);
         props.put("mq.user.authentication.mqcsp", "false");
+        props.put("topic", "mytopic");
         return props;
     }
 
@@ -82,6 +83,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
         assertEquals(2, kafkaMessages.size());
         for (final SourceRecord kafkaMessage : kafkaMessages) {
+            assertEquals("mytopic", kafkaMessage.topic());
             assertNull(kafkaMessage.key());
             assertNull(kafkaMessage.valueSchema());
 
@@ -116,6 +118,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(5, kafkaMessages.size());
         for (int i = 0; i < 5; i++) {
             final SourceRecord kafkaMessage = kafkaMessages.get(i);
+            assertEquals("mytopic", kafkaMessage.topic());
             assertNull(kafkaMessage.key());
             assertNull(kafkaMessage.valueSchema());
 
@@ -148,6 +151,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
         assertEquals(1, kafkaMessages.size());
         final SourceRecord kafkaMessage = kafkaMessages.get(0);
+        assertEquals("mytopic", kafkaMessage.topic());
         assertNull(kafkaMessage.key());
         assertNull(kafkaMessage.valueSchema());
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
@@ -15,6 +15,9 @@
  */
 package com.ibm.eventstreams.connect.mqsource;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -25,14 +28,16 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MQSourceConnector extends SourceConnector {
     private static final Logger log = LoggerFactory.getLogger(MQSourceConnector.class);
+
+    public static final ConfigDef CONFIGDEF;
 
     public static final String CONFIG_GROUP_MQ = "mq";
 
@@ -218,104 +223,264 @@ public class MQSourceConnector extends SourceConnector {
      */
     @Override
     public ConfigDef config() {
-        final ConfigDef config = new ConfigDef();
+        return CONFIGDEF;
+    }
 
-        config.define(CONFIG_NAME_MQ_QUEUE_MANAGER, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, Importance.HIGH,
-                      CONFIG_DOCUMENTATION_MQ_QUEUE_MANAGER, CONFIG_GROUP_MQ, 1, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_QUEUE_MANAGER);
+    /** Null validator - indicates that any value is acceptable for this config option. */
+    private static final ConfigDef.Validator ANY = null;
 
-        config.define(CONFIG_NAME_MQ_CONNECTION_MODE, Type.STRING, CONFIG_VALUE_MQ_CONNECTION_MODE_CLIENT,
-                      ConfigDef.ValidString.in(CONFIG_VALUE_MQ_CONNECTION_MODE_CLIENT,
-                                               CONFIG_VALUE_MQ_CONNECTION_MODE_BINDINGS),
-                      Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_CONNECTION_MODE, CONFIG_GROUP_MQ, 2, Width.SHORT,
-                      CONFIG_DISPLAY_MQ_CONNECTION_MODE);
+    static {
+        CONFIGDEF = new ConfigDef();
 
-        config.define(CONFIG_NAME_MQ_CONNECTION_NAME_LIST, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_CONNNECTION_NAME_LIST, CONFIG_GROUP_MQ, 3, Width.LONG,
-                      CONFIG_DISPLAY_MQ_CONNECTION_NAME_LIST);
+        CONFIGDEF.define(CONFIG_NAME_MQ_QUEUE_MANAGER,
+                         Type.STRING,
+                         // user must specify the queue manager name
+                         ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.NonEmptyStringWithoutControlChars(),
+                         Importance.HIGH,
+                         CONFIG_DOCUMENTATION_MQ_QUEUE_MANAGER,
+                         CONFIG_GROUP_MQ, 1, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_QUEUE_MANAGER);
 
-        config.define(CONFIG_NAME_MQ_CHANNEL_NAME, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_CHANNEL_NAME, CONFIG_GROUP_MQ, 4, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_CHANNEL_NAME);
+        CONFIGDEF.define(CONFIG_NAME_MQ_CONNECTION_MODE,
+                         Type.STRING,
+                         // required value - two valid options
+                         CONFIG_VALUE_MQ_CONNECTION_MODE_CLIENT,
+                         ConfigDef.ValidString.in(CONFIG_VALUE_MQ_CONNECTION_MODE_CLIENT,
+                                                  CONFIG_VALUE_MQ_CONNECTION_MODE_BINDINGS),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_CONNECTION_MODE,
+                         CONFIG_GROUP_MQ, 2, Width.SHORT,
+                         CONFIG_DISPLAY_MQ_CONNECTION_MODE);
 
-        config.define(CONFIG_NAME_MQ_CCDT_URL, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_CCDT_URL, CONFIG_GROUP_MQ, 5, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_CCDT_URL);
+        CONFIGDEF.define(CONFIG_NAME_MQ_CONNECTION_NAME_LIST,
+                         Type.STRING,
+                         // can be null, for example when using bindings mode or a CCDT
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_CONNNECTION_NAME_LIST,
+                         CONFIG_GROUP_MQ, 3, Width.LONG,
+                         CONFIG_DISPLAY_MQ_CONNECTION_NAME_LIST);
 
-        config.define(CONFIG_NAME_MQ_QUEUE, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, Importance.HIGH,
-                      CONFIG_DOCUMENTATION_MQ_QUEUE, CONFIG_GROUP_MQ, 6, Width.LONG,
-                      CONFIG_DISPLAY_MQ_QUEUE);
+        CONFIGDEF.define(CONFIG_NAME_MQ_CHANNEL_NAME,
+                         Type.STRING,
+                         // can be null, for example when using bindings mode
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_CHANNEL_NAME,
+                         CONFIG_GROUP_MQ, 4, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_CHANNEL_NAME);
 
-        config.define(CONFIG_NAME_MQ_USER_NAME, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_USER_NAME, CONFIG_GROUP_MQ, 7, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_USER_NAME);
+        CONFIGDEF.define(CONFIG_NAME_MQ_CCDT_URL,
+                         Type.STRING,
+                         // can be null, for example when using bindings mode or a conname list
+                         null, new ValidURL(),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_CCDT_URL,
+                         CONFIG_GROUP_MQ, 5, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_CCDT_URL);
 
-        config.define(CONFIG_NAME_MQ_PASSWORD, Type.PASSWORD, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_PASSWORD, CONFIG_GROUP_MQ, 8, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_PASSWORD);
+        CONFIGDEF.define(CONFIG_NAME_MQ_QUEUE,
+                         Type.STRING,
+                         // user must specify the queue name
+                         ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.NonEmptyStringWithoutControlChars(),
+                         Importance.HIGH,
+                         CONFIG_DOCUMENTATION_MQ_QUEUE,
+                         CONFIG_GROUP_MQ, 6, Width.LONG,
+                         CONFIG_DISPLAY_MQ_QUEUE);
 
-        config.define(CONFIG_NAME_MQ_RECORD_BUILDER, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, Importance.HIGH,
-                      CONFIG_DOCUMENTATION_MQ_RECORD_BUILDER, CONFIG_GROUP_MQ, 9, Width.LONG,
-                      CONFIG_DISPLAY_MQ_RECORD_BUILDER);
+        CONFIGDEF.define(CONFIG_NAME_MQ_USER_NAME,
+                         Type.STRING,
+                         // can be null, when auth not required
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_USER_NAME,
+                         CONFIG_GROUP_MQ, 7, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_USER_NAME);
 
-        config.define(CONFIG_NAME_MQ_MESSAGE_BODY_JMS, Type.BOOLEAN, Boolean.FALSE, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_MESSAGE_BODY_JMS, CONFIG_GROUP_MQ, 10, Width.SHORT,
-                      CONFIG_DISPLAY_MQ_MESSAGE_BODY_JMS);
+        CONFIGDEF.define(CONFIG_NAME_MQ_PASSWORD,
+                         Type.PASSWORD,
+                         // can be null, when auth not required
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_PASSWORD,
+                         CONFIG_GROUP_MQ, 8, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_PASSWORD);
 
-        config.define(CONFIG_NAME_MQ_RECORD_BUILDER_KEY_HEADER, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_RECORD_BUILDER_KEY_HEADER, CONFIG_GROUP_MQ, 11, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_RECORD_BUILDER_KEY_HEADER);
+        CONFIGDEF.define(CONFIG_NAME_MQ_RECORD_BUILDER,
+                         Type.STRING,
+                         // user must specify a record builder class
+                         ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.NonEmptyStringWithoutControlChars(),
+                         Importance.HIGH,
+                         CONFIG_DOCUMENTATION_MQ_RECORD_BUILDER,
+                         CONFIG_GROUP_MQ, 9, Width.LONG,
+                         CONFIG_DISPLAY_MQ_RECORD_BUILDER);
 
-        config.define(CONFIG_NAME_MQ_SSL_CIPHER_SUITE, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_CIPHER_SUITE, CONFIG_GROUP_MQ, 12, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_CIPHER_SUITE);
+        CONFIGDEF.define(CONFIG_NAME_MQ_MESSAGE_BODY_JMS,
+                         Type.BOOLEAN,
+                         // must be a non-null boolean - assume false if not provided
+                         Boolean.FALSE, new ConfigDef.NonNullValidator(),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_MESSAGE_BODY_JMS,
+                         CONFIG_GROUP_MQ, 10, Width.SHORT,
+                         CONFIG_DISPLAY_MQ_MESSAGE_BODY_JMS);
 
-        config.define(CONFIG_NAME_MQ_SSL_PEER_NAME, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_PEER_NAME, CONFIG_GROUP_MQ, 13, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_PEER_NAME);
+        CONFIGDEF.define(CONFIG_NAME_MQ_RECORD_BUILDER_KEY_HEADER,
+                         Type.STRING,
+                         // optional value - four valid values
+                         null, ConfigDef.ValidString.in(null,
+                                                        CONFIG_VALUE_MQ_RECORD_BUILDER_KEY_HEADER_JMSMESSAGEID,
+                                                        CONFIG_VALUE_MQ_RECORD_BUILDER_KEY_HEADER_JMSCORRELATIONID,
+                                                        CONFIG_VALUE_MQ_RECORD_BUILDER_KEY_HEADER_JMSCORRELATIONIDASBYTES,
+                                                        CONFIG_VALUE_MQ_RECORD_BUILDER_KEY_HEADER_JMSDESTINATION),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_RECORD_BUILDER_KEY_HEADER,
+                         CONFIG_GROUP_MQ, 11, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_RECORD_BUILDER_KEY_HEADER);
 
-        config.define(CONFIG_NAME_MQ_SSL_KEYSTORE_LOCATION, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_KEYSTORE_LOCATION, CONFIG_GROUP_MQ, 14, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_KEYSTORE_LOCATION);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_CIPHER_SUITE,
+                         Type.STRING,
+                         // optional - not needed if not using SSL - SSL cipher suites change
+                         //   too frequently so we won't maintain a valid list here
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_CIPHER_SUITE,
+                         CONFIG_GROUP_MQ, 12, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_CIPHER_SUITE);
 
-        config.define(CONFIG_NAME_MQ_SSL_KEYSTORE_PASSWORD, Type.PASSWORD, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_KEYSTORE_PASSWORD, CONFIG_GROUP_MQ, 15, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_KEYSTORE_PASSWORD);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_PEER_NAME,
+                         Type.STRING,
+                         // optional - not needed if not using SSL
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_PEER_NAME,
+                         CONFIG_GROUP_MQ, 13, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_PEER_NAME);
 
-        config.define(CONFIG_NAME_MQ_SSL_TRUSTSTORE_LOCATION, Type.STRING, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_TRUSTSTORE_LOCATION, CONFIG_GROUP_MQ, 16, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_TRUSTSTORE_LOCATION);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_KEYSTORE_LOCATION,
+                         Type.STRING,
+                         // optional - if provided should be the location of a readable file
+                         null, new ReadableFile(),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_KEYSTORE_LOCATION,
+                         CONFIG_GROUP_MQ, 14, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_KEYSTORE_LOCATION);
 
-        config.define(CONFIG_NAME_MQ_SSL_TRUSTSTORE_PASSWORD, Type.PASSWORD, null, Importance.MEDIUM,
-                      CONFIG_DOCUMENTATION_MQ_SSL_TRUSTSTORE_PASSWORD, CONFIG_GROUP_MQ, 17, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_SSL_TRUSTSTORE_PASSWORD);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_KEYSTORE_PASSWORD,
+                         Type.PASSWORD,
+                         // optional - not needed if SSL keystore isn't provided
+                         null, ANY,
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_KEYSTORE_PASSWORD,
+                         CONFIG_GROUP_MQ, 15, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_KEYSTORE_PASSWORD);
 
-        config.define(CONFIG_NAME_MQ_BATCH_SIZE, Type.INT, CONFIG_VALUE_MQ_BATCH_SIZE_DEFAULT,
-                      ConfigDef.Range.atLeast(CONFIG_VALUE_MQ_BATCH_SIZE_MINIMUM), Importance.LOW,
-                      CONFIG_DOCUMENTATION_MQ_BATCH_SIZE, CONFIG_GROUP_MQ, 18, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_BATCH_SIZE);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_TRUSTSTORE_LOCATION,
+                         Type.STRING,
+                         // optional - if provided should be the location of a readable file
+                         null, new ReadableFile(),
+                         Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_TRUSTSTORE_LOCATION,
+                         CONFIG_GROUP_MQ, 16, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_TRUSTSTORE_LOCATION);
 
-        config.define(CONFIG_NAME_MQ_MESSAGE_MQMD_READ, Type.BOOLEAN, Boolean.FALSE, Importance.LOW,
-                      CONFIG_DOCUMENTATION_MQ_MESSAGE_MQMD_READ, CONFIG_GROUP_MQ, 19, Width.SHORT,
-                      CONFIG_DISPLAY_MQ_MESSAGE_MQMD_READ);
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_TRUSTSTORE_PASSWORD,
+                         Type.PASSWORD,
+                         // optional - not needed if SSL truststore isn't provided
+                         null, Importance.MEDIUM,
+                         CONFIG_DOCUMENTATION_MQ_SSL_TRUSTSTORE_PASSWORD,
+                         CONFIG_GROUP_MQ, 17, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_SSL_TRUSTSTORE_PASSWORD);
 
-        config.define(CONFIG_NAME_MQ_USER_AUTHENTICATION_MQCSP, Type.BOOLEAN, Boolean.TRUE, Importance.LOW,
-                      CONFIG_DOCUMENTATION_MQ_USER_AUTHENTICATION_MQCSP, CONFIG_GROUP_MQ, 20, Width.SHORT,
-                      CONFIG_DISPLAY_MQ_USER_AUTHENTICATION_MQCSP);
+        CONFIGDEF.define(CONFIG_NAME_MQ_BATCH_SIZE,
+                         Type.INT,
+                         // must be an int greater than min
+                         CONFIG_VALUE_MQ_BATCH_SIZE_DEFAULT, ConfigDef.Range.atLeast(CONFIG_VALUE_MQ_BATCH_SIZE_MINIMUM),
+                         Importance.LOW,
+                         CONFIG_DOCUMENTATION_MQ_BATCH_SIZE,
+                         CONFIG_GROUP_MQ, 18, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_BATCH_SIZE);
 
-        config.define(CONFIG_NAME_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER, Type.BOOLEAN, Boolean.FALSE, Importance.LOW,
-                      CONFIG_DOCUMENTATION_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER, CONFIG_GROUP_MQ, 21, Width.MEDIUM,
-                      CONFIG_DISPLAY_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER);
+        CONFIGDEF.define(CONFIG_NAME_MQ_MESSAGE_MQMD_READ,
+                         Type.BOOLEAN,
+                         // must be a non-null boolean - assume false if not provided
+                         Boolean.FALSE, new ConfigDef.NonNullValidator(),
+                         Importance.LOW,
+                         CONFIG_DOCUMENTATION_MQ_MESSAGE_MQMD_READ,
+                         CONFIG_GROUP_MQ, 19, Width.SHORT,
+                         CONFIG_DISPLAY_MQ_MESSAGE_MQMD_READ);
 
-        config.define(CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, Type.BOOLEAN, null, Importance.LOW,
-                      CONFIG_DOCUMENTATION_MQ_SSL_USE_IBM_CIPHER_MAPPINGS, CONFIG_GROUP_MQ, 22, Width.SHORT,
-                      CONFIG_DISPLAY_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
+        CONFIGDEF.define(CONFIG_NAME_MQ_USER_AUTHENTICATION_MQCSP,
+                         Type.BOOLEAN,
+                         // must be a non-null boolean - assume true if not provided
+                         Boolean.TRUE, new ConfigDef.NonNullValidator(),
+                         Importance.LOW,
+                         CONFIG_DOCUMENTATION_MQ_USER_AUTHENTICATION_MQCSP,
+                         CONFIG_GROUP_MQ, 20, Width.SHORT,
+                         CONFIG_DISPLAY_MQ_USER_AUTHENTICATION_MQCSP);
 
-        config.define(CONFIG_NAME_TOPIC, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, Importance.HIGH,
-                      CONFIG_DOCUMENTATION_TOPIC, null, 0, Width.MEDIUM,
-                      CONFIG_DISPLAY_TOPIC);
+        CONFIGDEF.define(CONFIG_NAME_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER,
+                         Type.BOOLEAN,
+                         // must be a non-null boolean - assume false if not provided
+                         Boolean.FALSE, new ConfigDef.NonNullValidator(),
+                         Importance.LOW,
+                         CONFIG_DOCUMENTATION_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER,
+                         CONFIG_GROUP_MQ, 21, Width.MEDIUM,
+                         CONFIG_DISPLAY_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER);
 
-        return config;
+        CONFIGDEF.define(CONFIG_NAME_MQ_SSL_USE_IBM_CIPHER_MAPPINGS,
+                         Type.BOOLEAN,
+                         // must be a non-null boolean - assume true if not provided
+                         Boolean.TRUE, new ConfigDef.NonNullValidator(),
+                         Importance.LOW,
+                         CONFIG_DOCUMENTATION_MQ_SSL_USE_IBM_CIPHER_MAPPINGS,
+                         CONFIG_GROUP_MQ, 22, Width.SHORT,
+                         CONFIG_DISPLAY_MQ_SSL_USE_IBM_CIPHER_MAPPINGS);
+
+        CONFIGDEF.define(CONFIG_NAME_TOPIC,
+                         Type.STRING,
+                         // user must specify the topic name
+                         ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.NonEmptyStringWithoutControlChars(),
+                         Importance.HIGH,
+                         CONFIG_DOCUMENTATION_TOPIC,
+                         null, 0, Width.MEDIUM,
+                         CONFIG_DISPLAY_TOPIC);
+    }
+
+
+    private static class ReadableFile implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            final String strValue = (String) value;
+            if (value == null || strValue.isEmpty()) {
+                // only validate non-empty locations
+                return;
+            }
+
+            try {
+                final File file = new File((String) value);
+                if (!file.isFile() || !file.canRead()) {
+                    throw new ConfigException(name, value, "Value must be the location of a readable file");
+                }
+            } catch (final Exception exc) {
+                throw new ConfigException(name, value, "Value must be a valid file location");
+            }
+        }
+    }
+
+    private static class ValidURL implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            final String strValue = (String) value;
+            if (value == null || strValue.isEmpty()) {
+                // only validate non-empty locations
+                return;
+            }
+
+            try {
+                new URL(strValue);
+            } catch (final MalformedURLException exc) {
+                throw new ConfigException(name, value, "Value must be a valid URL");
+            }
+        }
     }
 }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceTask.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceTask.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 
@@ -71,14 +72,13 @@ public class MQSourceTask extends SourceTask {
             log.debug("Task props entry {} : {}", entry.getKey(), value);
         }
 
-        final String strBatchSize = props.get(MQSourceConnector.CONFIG_NAME_MQ_BATCH_SIZE);
-        if (strBatchSize != null) {
-            batchSize = Integer.parseInt(strBatchSize);
-        }
+        final AbstractConfig config = new AbstractConfig(MQSourceConnector.CONFIGDEF, props);
+
+        batchSize = config.getInt(MQSourceConnector.CONFIG_NAME_MQ_BATCH_SIZE);
 
         // Construct a reader to interface with MQ
         reader = new JMSReader();
-        reader.configure(props);
+        reader.configure(config);
 
         // Make a connection as an initial test of the configuration
         reader.connect();


### PR DESCRIPTION
# Description

The connector was doing a lot of it's own processing of config options - type-checking, null-checking, casting, etc.

This makes the connector-specific aspects of the code harder to follow, and it also makes it easier for us to miss validating some required config options (for example, we weren't checking that topic names were provided).

This commit moves all of this out of the connector, and makes it the responsibility of the Kafka Connect framework. This removes a lot of unnecessary checking and type checking/casting from the connector code, as the source task and jms reader class can assume that they will be given a validated config.

For example, repeated blocks of code like this:
```java
boolean optionAsBool = false; // default value
String optionAsString = props.get(MQSourceConnector.SOME_OPTION_KEY);
if (optionAsString != null) {
     optionAsBool = Boolean.parseBoolean(optionAsString);
}
```

becomes:
```java
boolean optionAsBool = options.getBoolean(MQSourceConnector.SOME_OPTION_KEY);
```

Note that I did have to leave the existing Map<String, String> parameter in the record builder as that is a public interface that users have subclassed. This should ideally be a Kafka Connect object rather than a raw map, but in the interest of not breaking existing subclasses, I've left it as a map. This does mean I'm converting the properties map to a config object twice, but as this is only at startup I think the performance cost will be minimal.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

none of these - no functional change should be observed

## How Has This Been Tested?

existing tests verify no regressions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
