### PR TITLE
Bug fix - Null handling for empty values in JMS Header properties 

### DIFF
--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/processor/JmsToKafkaHeaderConverter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/processor/JmsToKafkaHeaderConverter.java
@@ -48,7 +48,13 @@ public class JmsToKafkaHeaderConverter {
 
             jmsPropertyKeys.forEach(key -> {
                 try {
-                    connectHeaders.addString(key.toString(), message.getObjectProperty(key.toString()).toString());
+                    String value = "";
+                    if (message.getObjectProperty(key.toString()) != null)
+                    {
+                        value = message.getObjectProperty(key.toString()).toString();
+                    }
+                    connectHeaders.addString(key.toString(), value);
+                   //connectHeaders.addString(key.toString(), message.getObjectProperty(key.toString()).toString());
                 } catch (final JMSException e) {
                     // Not failing the message processing if JMS properties cannot be read for some
                     // reason.

--- a/src/test/java/com/ibm/eventstreams/connect/mqsource/JmsToKafkaHeaderConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsource/JmsToKafkaHeaderConverterTest.java
@@ -44,7 +44,7 @@ public class JmsToKafkaHeaderConverterTest {
     @Test
     public void convertJmsPropertiesToKafkaHeaders() throws JMSException {
 
-        final List<String> keys = Arrays.asList("facilityCountryCode", "facilityNum");
+        final List<String> keys = Arrays.asList("facilityCountryCode", "facilityNum","nullProperty");
 
         final Enumeration<String> keyEnumeration = Collections.enumeration(keys);
 
@@ -52,6 +52,7 @@ public class JmsToKafkaHeaderConverterTest {
         when(message.getPropertyNames()).thenReturn(keyEnumeration);
         when(message.getObjectProperty("facilityCountryCode")).thenReturn("US");
         when(message.getObjectProperty("facilityNum")).thenReturn("12345");
+        when(message.getObjectProperty("nullProperty")).thenReturn(null);
 
         // Act
         final ConnectHeaders actualConnectHeaders = jmsToKafkaHeaderConverter
@@ -59,7 +60,7 @@ public class JmsToKafkaHeaderConverterTest {
 
 
         //Verify
-        assertEquals("Both custom JMS properties were copied to kafka successfully.", 2, actualConnectHeaders.size());
+        assertEquals("Both custom JMS properties were copied to kafka successfully.", 3, actualConnectHeaders.size());
 
 
     }


### PR DESCRIPTION
In MQ, if the value for any of the JMS property keys is empty, and  we set the property mq.jms.properties.copy.to.kafka.headers = true in our connector properties, the Kafka Connect pipeline fails with a "NullPointerException" while attaching those properties in my kafka headers , As a result, the messages are routed to the BO queue. 

Type of issue -  Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested? - YES 

* Tried setting the flag as false for mq.jms.properties.copy.to.kafka.headers  and there are no exception but the properties from my MQ is not attached to my kafka headers 

* Handled the scneario in the jmsToKafkaHeaderConverter class , where is the value for a key is empty/null then we are passing the value for that particular key as a empty string "" , by doing this the messages are not moving to BO queue and my kafka connect pipeline is running without any exception 


Checklist 
- [ ] My code follows the style guidelines of this project - YES
- [ ] I have performed a self-review of my code - YES
- [ ] I have commented my code, particularly in hard-to-understand areas - YES
- [ ] My changes generate no new warnings - YES
- [ ] I have added tests that prove my fix is effective or that my feature works - YES
- [ ] New and existing unit tests pass locally with my changes - YES
