### PR TITLE
Replace deprecated commitRecord method to support Kafka 4.0

### DIFF
--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskAuthIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskAuthIT.java
@@ -110,7 +110,7 @@ public class MQSourceTaskAuthIT {
             assertNull(kafkaMessage.key());
             assertEquals(Schema.OPTIONAL_BYTES_SCHEMA, kafkaMessage.valueSchema());
 
-            newConnectTask.commitRecord(kafkaMessage);
+            newConnectTask.commitRecord(kafkaMessage, null);
         }
 
         assertArrayEquals("hello".getBytes(), (byte[]) kafkaMessages.get(0).value());

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskExceptionHandlingIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskExceptionHandlingIT.java
@@ -221,7 +221,7 @@ public class MQSourceTaskExceptionHandlingIT extends AbstractJMSContextIT {
         assertThat(exc).isNotNull();
         assertThat(exc).isInstanceOf(RetriableException.class);
         for (SourceRecord record : sourceRecords) {
-            connectTask.commitRecord(record);
+            connectTask.commitRecord(record, null);
         }
 
         assertThat(sourceRecords.size()).isEqualTo(0);
@@ -341,7 +341,7 @@ public class MQSourceTaskExceptionHandlingIT extends AbstractJMSContextIT {
         try {
             sourceRecords = connectTask.poll();
             for (SourceRecord record : sourceRecords) {
-                connectTask.commitRecord(record);
+                connectTask.commitRecord(record, null);
             }
 
         } catch(Exception e) {

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
@@ -126,7 +126,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
             assertNull(kafkaMessage.key());
             assertNull(kafkaMessage.valueSchema());
 
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertEquals("hello", kafkaMessages.get(0).value());
@@ -163,7 +163,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
             final Map<?, ?> value = (Map<?, ?>) kafkaMessage.value();
             assertEquals(Long.valueOf(i), value.get("i"));
 
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
     }
 
@@ -192,7 +192,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(received.getClass(), byte[].class);
         assertEquals(new String((byte[]) received, StandardCharsets.UTF_8), sent);
 
-        connectTask.commitRecord(firstMsg);
+        connectTask.commitRecord(firstMsg, null);
         connectTask.poll();
     }
 
@@ -227,7 +227,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals("11", kafkaMessage.headers().lastWithName("volume").value());
         assertEquals("42.0", kafkaMessage.headers().lastWithName("decimalmeaning").value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -254,28 +254,28 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord kafkaMessage : kafkaMessages) {
             assertEquals("batch message " + (nextExpectedMessage++), kafkaMessage.value());
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord kafkaMessage : kafkaMessages) {
             assertEquals("batch message " + (nextExpectedMessage++), kafkaMessage.value());
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord kafkaMessage : kafkaMessages) {
             assertEquals("batch message " + (nextExpectedMessage++), kafkaMessage.value());
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(5, kafkaMessages.size());
         for (final SourceRecord kafkaMessage : kafkaMessages) {
             assertEquals("batch message " + (nextExpectedMessage++), kafkaMessage.value());
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
     }
 
@@ -299,25 +299,25 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         kafkaMessages = connectTask.poll();
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(10, kafkaMessages.size());
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
 
         kafkaMessages = connectTask.poll();
         assertEquals(5, kafkaMessages.size());
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
     }
 
@@ -346,7 +346,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         assertEquals("testmessage", kafkaMessage.value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -374,13 +374,13 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals("verifycorrel", kafkaMessage1.key());
         assertEquals(Schema.OPTIONAL_STRING_SCHEMA, kafkaMessage1.keySchema());
         assertEquals("first message", kafkaMessage1.value());
-        connectTask.commitRecord(kafkaMessage1);
+        connectTask.commitRecord(kafkaMessage1, null);
 
         final SourceRecord kafkaMessage2 = kafkaMessages.get(1);
         assertEquals("5fb4a18030154fe4b09a1dfe8075bc101dfe8075bc104fe4", kafkaMessage2.key());
         assertEquals(Schema.OPTIONAL_STRING_SCHEMA, kafkaMessage2.keySchema());
         assertEquals("second message", kafkaMessage2.value());
-        connectTask.commitRecord(kafkaMessage2);
+        connectTask.commitRecord(kafkaMessage2, null);
     }
 
     @Test
@@ -408,7 +408,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         assertEquals("testmessagewithcorrelbytes", kafkaMessage.value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -435,7 +435,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         assertEquals("testmessagewithdest", kafkaMessage.value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -467,7 +467,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertThat(stateMsgs1.size()).isEqualTo(1);
 
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
 
         /// make commit do rollback when poll is called
@@ -651,7 +651,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         final SourceRecord kafkaMessage = kafkaMessages.get(0);
         assertNull(kafkaMessage.value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -674,7 +674,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         final SourceRecord kafkaMessage = kafkaMessages.get(0);
         assertNull(kafkaMessage.value());
 
-        connectTask.commitRecord(kafkaMessage);
+        connectTask.commitRecord(kafkaMessage, null);
     }
 
     @Test
@@ -752,7 +752,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
             final Map<?, ?> value = (Map<?, ?>) validRecord.value();
             assertThat(value.get("i")).isEqualTo(Long.valueOf(i));
 
-            connectTask.commitRecord(validRecord);
+            connectTask.commitRecord(validRecord, null);
         }
     }
 
@@ -797,7 +797,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
             final Map<?, ?> value = (Map<?, ?>) validRecord.value();
             assertThat(value.get("i")).isEqualTo(Long.valueOf(i - 1));
 
-            connectTask.commitRecord(validRecord);
+            connectTask.commitRecord(validRecord, null);
         }
     }
 
@@ -876,7 +876,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(headers.lastWithName("__connect.errors.jms.message.id").value(), message.getJMSMessageID());
         assertEquals(headers.lastWithName("__connect.errors.jms.timestamp").value(), message.getJMSTimestamp());
         assertEquals(headers.lastWithName("__connect.errors.mq.queue").value(), DEFAULT_SOURCE_QUEUE);
-        connectTask.commitRecord(dlqRecord);
+        connectTask.commitRecord(dlqRecord, null);
     }
 
     @Test
@@ -910,7 +910,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         for (final SourceRecord dlqRecord : processedRecords) {
             assertThat(dlqRecord.topic()).isEqualTo("__dlq.mq.source");
             assertThat(dlqRecord.valueSchema().type()).isEqualTo(Schema.Type.BYTES);
-            connectTask.commitRecord(dlqRecord);
+            connectTask.commitRecord(dlqRecord, null);
         }
     }
 
@@ -943,7 +943,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertThat(headers.lastWithName("__connect.errors.exception.message").value())
                 .isEqualTo("Converting byte[] to Kafka Connect data failed due to serialization error: ");
 
-        connectTask.commitRecord(dlqRecord);
+        connectTask.commitRecord(dlqRecord, null);
     }
 
     @Test
@@ -984,7 +984,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
                 validCount++;
                 assertThat(record.topic()).isEqualTo("mytopic");
             }
-            connectTask.commitRecord(record);
+            connectTask.commitRecord(record, null);
         }
 
         assertThat(validCount).isEqualTo(3);

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskOnlyOnceIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskOnlyOnceIT.java
@@ -126,7 +126,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)
@@ -145,7 +145,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)
@@ -166,7 +166,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(getSequenceStateAndAssertNotEmpty()).isEqualTo(new SequenceState(
@@ -215,7 +215,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
                 .contains(sequenceId);
 
         for (final SourceRecord m : kafkaMessages) {
-            connectTask.commitRecord(m);
+            connectTask.commitRecord(m, null);
         }
 
         assertThat(getSequenceStateAndAssertNotEmpty()).isEqualTo(new SequenceState(
@@ -246,7 +246,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> sourceRecords = connectTask.poll();
 
         for (final SourceRecord sourceRecord : sourceRecords) {
-            connectTask.commitRecord(sourceRecord);
+            connectTask.commitRecord(sourceRecord, null);
         }
 
         assertThat(sourceRecords)
@@ -275,7 +275,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)
@@ -298,7 +298,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)
@@ -329,7 +329,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)
@@ -349,7 +349,7 @@ public class MQSourceTaskOnlyOnceIT extends AbstractJMSContextIT {
         kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessages)

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskOnlyOnceStartBehaviourIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskOnlyOnceStartBehaviourIT.java
@@ -128,7 +128,7 @@ public class MQSourceTaskOnlyOnceStartBehaviourIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         // Check that MQ has been read from
@@ -169,7 +169,7 @@ public class MQSourceTaskOnlyOnceStartBehaviourIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessages = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessages) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         // Check that MQ has been read from
@@ -500,7 +500,7 @@ public class MQSourceTaskOnlyOnceStartBehaviourIT extends AbstractJMSContextIT {
         assertThat(kafkaMessagesRoundOne.size()).isEqualTo(2);
 
         for (final SourceRecord kafkaMessage : kafkaMessagesRoundOne) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessagesRoundOne)
@@ -518,7 +518,7 @@ public class MQSourceTaskOnlyOnceStartBehaviourIT extends AbstractJMSContextIT {
         assertThat(kafkaMessagesRoundTwo.size()).isEqualTo(2);
 
         for (final SourceRecord kafkaMessage : kafkaMessagesRoundTwo) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         assertThat(kafkaMessagesRoundTwo)
@@ -540,7 +540,7 @@ public class MQSourceTaskOnlyOnceStartBehaviourIT extends AbstractJMSContextIT {
         final List<SourceRecord> kafkaMessagesRoundThree = connectTask.poll();
 
         for (final SourceRecord kafkaMessage : kafkaMessagesRoundThree) {
-            connectTask.commitRecord(kafkaMessage);
+            connectTask.commitRecord(kafkaMessage, null);
         }
 
         // These messages would have been returned if onlyOnce wasn't implemented.

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceTask.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceTask.java
@@ -22,6 +22,8 @@ import com.ibm.eventstreams.connect.mqsource.sequencestate.SequenceStateExceptio
 import com.ibm.eventstreams.connect.mqsource.util.LogMessages;
 import com.ibm.eventstreams.connect.mqsource.util.ExceptionProcessor;
 import com.ibm.eventstreams.connect.mqsource.util.QueueConfig;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -533,7 +535,7 @@ public class MQSourceTask extends SourceTask {
      * @throws InterruptedException
      */
     @Override
-    public void commitRecord(final SourceRecord record) throws InterruptedException {
+    public void commitRecord(final SourceRecord record, final RecordMetadata metadata) throws InterruptedException {
         log.trace("[{}] Entry {}.commitRecord, record={}", Thread.currentThread().getId(), this.getClass().getName(),
                 record);
 

--- a/src/test/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskTest.java
@@ -240,7 +240,7 @@ public class MQSourceTaskTest {
                 assertThat(pollDuringCommits).isNull();
             }
 
-            mqSourceTask.commitRecord(firstConnectMessagesBatch.get(i));
+            mqSourceTask.commitRecord(firstConnectMessagesBatch.get(i), null);
         }
 
         // now all messages are committed, a poll should return messages


### PR DESCRIPTION
# Description

This Pull Request updates the usage of the deprecated commitRecord method to the new method introduced in Kafka 4.0.

The method signature:
`public void commitRecord(final SourceRecord record) throws InterruptedException`

has been replaced with:
`public void commitRecord(final SourceRecord record, final RecordMetadata metadata) throws InterruptedException`


All usages of the old method have been updated accordingly. For example:\
`newConnectTask.commitRecord(kafkaMessage);`

has been changed to:
`newConnectTask.commitRecord(kafkaMessage, null);`

This ensures compatibility with Kafka 4.0 while maintaining existing functionality.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

none of these - no functional change should be observed

## How Has This Been Tested?

existing tests verify no regressions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
