### PR TITLE
fix: remove kafka 4 incompatible message from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The connector is supplied as source code which you can easily build into a JAR f
 
 **Note**: A sink connector for IBM MQ is also available on [GitHub](https://github.com/ibm-messaging/kafka-connect-mq-sink).
 
-**Kafka version support**: This connector supports Kafka versions upto 3.9. It is not compatible with Kafka 4.x.
-
 ## Contents
 
 - [Building the connector](#building-the-connector)


### PR DESCRIPTION
This pull request makes a minor documentation update by removing an outdated statement about Kafka version support from the `README.md`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
