### PR TITLE
fix: Propagate message property types to Kafka headers and update tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -58,7 +58,7 @@ body:
       description: What version of our software are you running?
       options:
         - latest
-        - 2.8.1 (Default)
+        - 3.0.0 (Default)
         - 1.3.5
         - older (<1.3.5)
     validations:

--- a/README.md
+++ b/README.md
@@ -259,8 +259,26 @@ If you write your own RecordBuilder, you can access the MQMD fields of the MQ me
 ### JMS message properties as Kafka headers
 
 When `mq.jms.properties.copy.to.kafka.headers` is set to `true`, JMS message properties are copied to Kafka headers.
-**Note**: When `mq.message.mqmd.read=true`, MQMD fields (such as `JMS_IBM_MQMD_Priority`, `JMS_IBM_MQMD_MsgId`, `JMS_IBM_MQMD_CorrelId`) become available as JMS properties .
- 
+
+**Note**: When `mq.message.mqmd.read=true`, MQMD fields (such as `JMS_IBM_MQMD_Priority`, `JMS_IBM_MQMD_MsgId`, `JMS_IBM_MQMD_CorrelId`) become available as JMS properties.
+
+#### Header type mapping
+
+JMS message properties are propagated to Kafka headers with their native types preserved. The Connect header schema assigned to each property reflects the original JMS type:
+
+| JMS property type | Connect header schema | Example value |
+| ----------------- | --------------------- | ------------- |
+| `String`          | `Schema.STRING`       | `"hello"`     |
+| `boolean`         | `Schema.BOOLEAN`      | `true`        |
+| `byte`            | `Schema.INT8`         | `64`          |
+| `short`           | `Schema.INT16`        | `1000`        |
+| `int`             | `Schema.INT32`        | `42`          |
+| `long`            | `Schema.INT64`        | `123456789`   |
+| `float`           | `Schema.FLOAT32`      | `1.5`         |
+| `double`          | `Schema.FLOAT64`      | `3.14`        |
+| `byte[]`          | `Schema.BYTES`        | `[0x01, ...]` |
+
+**Upgrade note**: Prior to this change, all non-byte-array JMS properties were converted to strings before being placed in Kafka headers. If you are upgrading from an earlier version and your downstream consumers expect string-typed headers for numeric or boolean properties (for example, `"42"` instead of `42`), you will need to update those consumers to handle the correctly-typed values.
 
 ## Security
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <groupId>com.ibm.eventstreams.connect</groupId>
     <artifactId>kafka-connect-mq-source</artifactId>
     <packaging>jar</packaging>
-    <version>2.8.1</version>
+    <version>3.0.0</version>
     <name>kafka-connect-mq-source</name>
     <organization>
         <name>IBM Corporation</name>

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceDLQIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceDLQIT.java
@@ -565,8 +565,8 @@ public class MQSourceDLQIT extends AbstractJMSContextIT {
 
         // Actual headers
         assertThat(headers.lastWithName("teststring").value()).isEqualTo("myvalue");
-        assertThat(headers.lastWithName("volume").value()).isEqualTo("11");
-        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo("42.0");
+        assertThat(headers.lastWithName("volume").value()).isEqualTo(11);
+        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo(42.0);
 
         // Expected DLQ Headers
         /**
@@ -639,8 +639,8 @@ public class MQSourceDLQIT extends AbstractJMSContextIT {
 
         // Actual headers
         assertThat(headers.lastWithName("teststring").value()).isEqualTo("myvalue");
-        assertThat(headers.lastWithName("volume").value()).isEqualTo("11");
-        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo("42.0");
+        assertThat(headers.lastWithName("volume").value()).isEqualTo(11);
+        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo(42.0);
 
         assertThat(headers.lastWithName("__connect.errors.topic")).isNull();
         assertThat(headers.lastWithName("__connect.errors.class.name")).isNull();
@@ -829,8 +829,8 @@ public class MQSourceDLQIT extends AbstractJMSContextIT {
 
         // Actual headers
         assertThat(headers.lastWithName("teststring").value()).isEqualTo("myvalue");
-        assertThat(headers.lastWithName("volume").value()).isEqualTo("11");
-        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo("42.0");
+        assertThat(headers.lastWithName("volume").value()).isEqualTo(11);
+        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo(42.0);
 
         assertThat(headers.lastWithName("__connect.errors.topic")).isNull();
         assertThat(headers.lastWithName("__connect.errors.class.name")).isNull();
@@ -886,8 +886,8 @@ public class MQSourceDLQIT extends AbstractJMSContextIT {
 
         // Actual headers
         assertThat(headers.lastWithName("teststring").value()).isEqualTo("myvalue");
-        assertThat(headers.lastWithName("volume").value()).isEqualTo("11");
-        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo("42.0");
+        assertThat(headers.lastWithName("volume").value()).isEqualTo(11);
+        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo(42.0);
 
         assertThat(headers.lastWithName("__connect.errors.topic")).isNull();
         assertThat(headers.lastWithName("__connect.errors.class.name")).isNull();

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskHeadersJsonIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskHeadersJsonIT.java
@@ -1,0 +1,603 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsource;
+
+import static com.ibm.eventstreams.connect.mqsource.MQSourceTaskObjectMother.getSourceTaskWithEmptyKafkaOffset;
+import static com.ibm.eventstreams.connect.mqsource.utils.MQTestUtil.putAllMessagesToQueue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jms.TextMessage;
+
+import com.ibm.msg.client.jms.JmsConstants;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsource.builders.DefaultRecordBuilder;
+import com.ibm.eventstreams.connect.mqsource.utils.MQTestUtil;
+import com.ibm.eventstreams.connect.mqsource.utils.SourceTaskStopper;
+
+/**
+ * Integration tests for copying JMS message properties to Kafka headers
+ *  using the JSON Connect header converter.
+ *
+ * JsonConverter is schema-sensitive so this is used to catch schema type 
+ *  bugs that using the default SimpleHeaderConverter cannot reveal.
+ */
+public class MQSourceTaskHeadersJsonIT extends AbstractJMSContextIT {
+
+    private static final String TOPIC = "mytopic";
+
+    private static final byte[] TEST_CORREL_ID = new byte[] {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18
+    };
+
+    private MQSourceTask connectTask = null;
+    private HeaderConverter converter;
+
+    @Before
+    public void before() throws Exception {
+        MQTestUtil.removeAllMessagesFromQueue(DEFAULT_SOURCE_QUEUE);
+        converter = new JsonConverter();
+
+        final Map<String, String> converterConfig = new HashMap<>();
+        converterConfig.put("schemas.enable", "false");
+        converterConfig.put("converter.type", "header");
+        converter.configure(converterConfig);
+    }
+
+    @After
+    public void after() throws InterruptedException {
+        final SourceTaskStopper stopper = new SourceTaskStopper(connectTask);
+        stopper.run();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Starts the connector task with header-copying enabled.
+     *
+     * @param mqmdRead true if MQMD fields should also be read
+     */
+    private void startTask(final boolean mqmdRead) {
+        connectTask = getSourceTaskWithEmptyKafkaOffset();
+
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.queue.manager", QMGR_NAME);
+        props.put("mq.connection.mode", "client");
+        props.put("mq.connection.name.list", DEFAULT_CONNECTION_NAME);
+        props.put("mq.channel.name", CHANNEL_NAME);
+        props.put("mq.queue", DEFAULT_SOURCE_QUEUE);
+        props.put("mq.user.authentication.mqcsp", "false");
+        props.put("topic", TOPIC);
+        props.put("mq.message.receive.timeout", "5000");
+        props.put("mq.receive.subsequent.timeout.ms", "2000");
+        props.put("mq.reconnect.delay.min.ms", "100");
+        props.put("mq.reconnect.delay.max.ms", "10000");
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_BODY_JMS, "true");
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_RECORD_BUILDER, DefaultRecordBuilder.class.getCanonicalName());
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER, "true");
+
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_MQMD_READ, Boolean.toString(mqmdRead));
+
+        connectTask.start(props);
+    }
+
+    /**
+     * Puts a single message to the queue, polls the connector, and
+     * returns the headers from the resulting SourceRecord.
+     */
+    private Headers pollHeaders(final TextMessage message) throws Exception {
+        putAllMessagesToQueue(DEFAULT_SOURCE_QUEUE, Arrays.asList(message));
+        final List<SourceRecord> records = connectTask.poll();
+        assertThat(records).hasSize(1);
+        return records.get(0).headers();
+    }
+
+    /**
+     * Serialises the named header through JsonConverter (as Connect would before
+     * writing to the Kafka topic) and returns the result decoded as a UTF-8
+     * string.
+     */
+    private String getHeaderAsJson(final Headers headers, final String headerName) {
+        final Header h = headers.lastWithName(headerName);
+        assertThat(h).isNotNull();
+        final byte[] wire = converter.fromConnectHeader(TOPIC, headerName, h.schema(), h.value());
+        assertThat(wire).isNotNull();
+        return new String(wire, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Returns the Connect schema type of the named header.
+     */
+    private Schema.Type getHeaderSchemaType(final Headers headers, final String headerName) {
+        final Header h = headers.lastWithName(headerName);
+        assertThat(h).isNotNull();
+        return h.schema().type();
+    }
+
+
+    // =========================================================================
+    // User-defined message properties
+    // =========================================================================
+
+    /**
+     * A JMS String property must produce a header with Schema.STRING.
+     * JsonConverter serialises this as a JSON string: "hello"
+     */
+    @Test
+    public void userDefinedStringProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setStringProperty("strProp", "hello");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "strProp")).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, "strProp")).isEqualTo("\"hello\"");
+    }
+
+    /**
+     * A JMS int property must produce a header with Schema.INT32.
+     * JsonConverter serialises this as a bare JSON number: 42
+     */
+    @Test
+    public void userDefinedIntProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setIntProperty("intProp", 42);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "intProp")).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, "intProp")).isEqualTo("42");
+    }
+
+    /**
+     * A JMS long property must produce a header with Schema.INT64.
+     * JsonConverter serialises this as a bare JSON number: 123456789012345
+     */
+    @Test
+    public void userDefinedLongProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setLongProperty("longProp", 123456789012345L);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "longProp")).isEqualTo(Schema.Type.INT64);
+        assertThat(getHeaderAsJson(headers, "longProp")).isEqualTo("123456789012345");
+    }
+
+    /**
+     * A JMS float property must produce a header with Schema.FLOAT32.
+     * JsonConverter serialises this as a bare JSON number: 1.5
+     */
+    @Test
+    public void userDefinedFloatProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setFloatProperty("floatProp", 1.5f);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "floatProp")).isEqualTo(Schema.Type.FLOAT32);
+        assertThat(getHeaderAsJson(headers, "floatProp")).isEqualTo("1.5");
+    }
+
+    /**
+     * A JMS double property must produce a header with Schema.FLOAT64.
+     * JsonConverter serialises this as a bare JSON number.
+     */
+    @Test
+    public void userDefinedDoubleProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setDoubleProperty("doubleProp", 3.141592653589793);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "doubleProp")).isEqualTo(Schema.Type.FLOAT64);
+        assertThat(getHeaderAsJson(headers, "doubleProp")).isEqualTo("3.141592653589793");
+    }
+
+    /**
+     * A JMS boolean property must produce a header with Schema.BOOLEAN.
+     * JsonConverter serialises this as a bare JSON boolean: true
+     */
+    @Test
+    public void userDefinedBooleanProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setBooleanProperty("boolProp", true);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "boolProp")).isEqualTo(Schema.Type.BOOLEAN);
+        assertThat(getHeaderAsJson(headers, "boolProp")).isEqualTo("true");
+    }
+
+    /**
+     * A JMS byte property (signed 8-bit integer) must produce a header with
+     * Schema.INT8.  JsonConverter serialises this as a bare JSON number: 64
+     */
+    @Test
+    public void userDefinedByteProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setByteProperty("byteProp", (byte) 64);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "byteProp")).isEqualTo(Schema.Type.INT8);
+        assertThat(getHeaderAsJson(headers, "byteProp")).isEqualTo("64");
+    }
+
+    /**
+     * A JMS short property must produce a header with Schema.INT16.
+     * JsonConverter serialises this as a bare JSON number: 1000
+     */
+    @Test
+    public void userDefinedShortProperty_schemaIsInt16() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setShortProperty("shortProp", (short) 1000);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, "shortProp")).isEqualTo(Schema.Type.INT16);
+        assertThat(getHeaderAsJson(headers, "shortProp")).isEqualTo("1000");
+    }
+
+
+    // =========================================================================
+    // JMSx properties (standard JMS) 
+    // =========================================================================
+
+    /**
+     * JMSXDeliveryCount is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsxDeliveryCount() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMSX_DELIVERY_COUNT)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_DELIVERY_COUNT)).isEqualTo("1");
+    }
+
+    /**
+     * JMSXUserID is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsxUserId() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMSX_USERID)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_USERID)).isEqualTo("\"app         \"");
+    }
+
+    /**
+     * JMSXGroupID is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsxGroupId() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setStringProperty(JmsConstants.JMSX_GROUPID, "MY_GROUP");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMSX_GROUPID)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_GROUPID)).isEqualTo("\"MY_GROUP\"");
+    }
+
+    /**
+     * JMSXGroupSeq is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsxGroupSeq() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setIntProperty(JmsConstants.JMSX_GROUPSEQ, 3);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMSX_GROUPSEQ)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_GROUPSEQ)).isEqualTo("3");
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_* extension properties 
+    // =========================================================================
+
+    /**
+     * JMS_IBM_Format is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmFormat() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_FORMAT)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_FORMAT)).isEqualTo("\"MQSTR   \"");
+    }
+
+    /**
+     * JMS_IBM_MsgType is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMsgType() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo(Schema.Type.INT32);
+        // a normal datagram sent without a reply-to destination has a type of 8 (MQMT_DATAGRAM)
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo("8");
+    }
+
+    /**
+     * JMS_IBM_Character_Set is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmCharacterSet() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo("\"UTF-8\"");
+    }
+
+    /**
+     * JMS_IBM_Encoding is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmEncoding() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_ENCODING)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_ENCODING)).isEqualTo("273");
+    }
+
+    /**
+     * JMS_IBM_PutDate is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmPutDate() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+        final String today = "\"" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")) + "\"";
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(today);
+    }
+
+    /**
+     * JMS_IBM_PutTime is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmPutTime() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_PUTTIME)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTTIME)).startsWith("\"").endsWith("\"");
+    }
+
+    /**
+     * JMS_IBM_PutApplType is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmPutApplType() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_PUTAPPLTYPE)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTAPPLTYPE)).matches("\\d+");
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_MQMD_* properties
+    // =========================================================================
+
+    /**
+     * JMS_IBM_MQMD_PutApplName is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmMqmdPutApplName() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME)).startsWith("\"").endsWith("\"");
+    }
+
+    /**
+     * JMS_IBM_MQMD_PutDate is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmMqmdPutDate() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+        final String today = "\"" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")) + "\"";
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(today);
+    }
+
+    /**
+     * JMS_IBM_MQMD_PutTime is a String property; must arrive as Schema.STRING.
+     */
+    @Test
+    public void jmsIbmMqmdPutTime() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_PUTTIME)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTTIME)).startsWith("\"").endsWith("\"");
+    }
+
+    /**
+     * JMS_IBM_MQMD_BackoutCount is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMqmdBackoutCount() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_BACKOUTCOUNT)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_BACKOUTCOUNT)).isEqualTo("0");
+    }    
+
+    /**
+     * JMS_IBM_MQMD_Priority is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMqmdPriority() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setJMSPriority(4);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo("4");
+    }
+
+    /**
+     * JMS_IBM_MQMD_Persistence is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMqmdPersistence() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo("1");
+    }    
+
+    /**
+     * JMS_IBM_MQMD_MsgType is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMqmdMsgType() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo("8");
+    }
+
+    /**
+     * JMS_IBM_MQMD_Encoding is an int property; must arrive as Schema.INT32.
+     */
+    @Test
+    public void jmsIbmMqmdEncoding() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo(Schema.Type.INT32);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo("273");
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_MSGID)).isEqualTo(Schema.Type.STRING);
+        final String json = getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(json).startsWith("\"ID:").endsWith("\"");
+    }
+
+    /**
+     * JMS_IBM_MQMD_CorrelId is returned as Schema.STRING via getJMSCorrelationID(),
+     * which formats it as "ID:" followed by lowercase hex digits.
+     * The hex encoding must round-trip the bytes set via setJMSCorrelationIDAsBytes().
+     */
+    @Test
+    public void jmsIbmMqmdCorrelId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setJMSCorrelationIDAsBytes(TEST_CORREL_ID);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_CORRELID)).isEqualTo(Schema.Type.STRING);
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_CORRELID))
+            .isEqualTo("\"ID:0102030405060708090a0b0c0d0e0f101112131415161718\"");
+    }
+
+    /**
+     * JMS_IBM_MQMD_AccountingToken is a 32-byte binary property; must arrive as Schema.BYTES.
+     */
+    @Test
+    public void jmsIbmMqmdAccountingToken() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN)).isEqualTo(Schema.Type.BYTES);
+        final String json = getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN);
+        assertThat(json).startsWith("\"").endsWith("\"");
+        final byte[] decoded = java.util.Base64.getDecoder().decode(json.substring(1, json.length() - 1));
+        assertThat(decoded).hasSize(32);
+    }
+
+    /**
+     * JMS_IBM_MQMD_GroupId is a 24-byte binary property; must arrive as Schema.BYTES.
+     */
+    @Test
+    public void jmsIbmMqmdGroupId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderSchemaType(headers, JmsConstants.JMS_IBM_MQMD_GROUPID)).isEqualTo(Schema.Type.BYTES);
+        final String json = getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_GROUPID);
+        assertThat(json).startsWith("\"").endsWith("\"");
+        final byte[] decoded = java.util.Base64.getDecoder().decode(json.substring(1, json.length() - 1));
+        assertThat(decoded).hasSize(24);
+    }
+}

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskHeadersSchemasIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskHeadersSchemasIT.java
@@ -1,0 +1,490 @@
+/**
+ * Copyright 2026 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventstreams.connect.mqsource;
+
+import static com.ibm.eventstreams.connect.mqsource.MQSourceTaskObjectMother.getSourceTaskWithEmptyKafkaOffset;
+import static com.ibm.eventstreams.connect.mqsource.utils.MQTestUtil.putAllMessagesToQueue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jms.TextMessage;
+
+import com.ibm.msg.client.jms.JmsConstants;
+
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.eventstreams.connect.mqsource.builders.DefaultRecordBuilder;
+import com.ibm.eventstreams.connect.mqsource.utils.MQTestUtil;
+import com.ibm.eventstreams.connect.mqsource.utils.SourceTaskStopper;
+
+/**
+ * Integration tests for copying JMS message properties to Kafka headers
+ *  using the JSON Connect header converter.
+ *
+ * JsonConverter is schema-sensitive so this is used to catch schema type 
+ *  bugs that using the default SimpleHeaderConverter cannot reveal.
+ */
+public class MQSourceTaskHeadersSchemasIT extends AbstractJMSContextIT {
+
+    private static final String TOPIC = "mytopic";
+
+    private static final byte[] TEST_CORREL_ID = new byte[] {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18
+    };
+
+    private MQSourceTask connectTask = null;
+    private HeaderConverter converter;
+
+    @Before
+    public void before() throws Exception {
+        MQTestUtil.removeAllMessagesFromQueue(DEFAULT_SOURCE_QUEUE);
+        converter = new JsonConverter();
+
+        final Map<String, String> converterConfig = new HashMap<>();
+        converterConfig.put("schemas.enable", "true");
+        converterConfig.put("converter.type", "header");
+        converter.configure(converterConfig);
+    }
+
+    @After
+    public void after() throws InterruptedException {
+        final SourceTaskStopper stopper = new SourceTaskStopper(connectTask);
+        stopper.run();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Starts the connector task with header-copying enabled.
+     *
+     * @param mqmdRead true if MQMD fields should also be read
+     */
+    private void startTask(final boolean mqmdRead) {
+        connectTask = getSourceTaskWithEmptyKafkaOffset();
+
+        final Map<String, String> props = new HashMap<>();
+        props.put("mq.queue.manager", QMGR_NAME);
+        props.put("mq.connection.mode", "client");
+        props.put("mq.connection.name.list", DEFAULT_CONNECTION_NAME);
+        props.put("mq.channel.name", CHANNEL_NAME);
+        props.put("mq.queue", DEFAULT_SOURCE_QUEUE);
+        props.put("mq.user.authentication.mqcsp", "false");
+        props.put("topic", TOPIC);
+        props.put("mq.message.receive.timeout", "5000");
+        props.put("mq.receive.subsequent.timeout.ms", "2000");
+        props.put("mq.reconnect.delay.min.ms", "100");
+        props.put("mq.reconnect.delay.max.ms", "10000");
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_BODY_JMS, "true");
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_RECORD_BUILDER, DefaultRecordBuilder.class.getCanonicalName());
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_JMS_PROPERTY_COPY_TO_KAFKA_HEADER, "true");
+
+        props.put(MQSourceConnector.CONFIG_NAME_MQ_MESSAGE_MQMD_READ, Boolean.toString(mqmdRead));
+
+        connectTask.start(props);
+    }
+
+    /**
+     * Puts a single message to the queue, polls the connector, and
+     * returns the headers from the resulting SourceRecord.
+     */
+    private Headers pollHeaders(final TextMessage message) throws Exception {
+        putAllMessagesToQueue(DEFAULT_SOURCE_QUEUE, Arrays.asList(message));
+        final List<SourceRecord> records = connectTask.poll();
+        assertThat(records).hasSize(1);
+        return records.get(0).headers();
+    }
+
+    /**
+     * Serialises the named header through JsonConverter (as Connect would before
+     * writing to the Kafka topic) and returns the result decoded as a UTF-8
+     * string.
+     */
+    private String getHeaderAsJson(final Headers headers, final String headerName) {
+        final Header h = headers.lastWithName(headerName);
+        assertThat(h).isNotNull();
+        final byte[] wire = converter.fromConnectHeader(TOPIC, headerName, h.schema(), h.value());
+        assertThat(wire).isNotNull();
+        System.out.println(new String(wire, StandardCharsets.UTF_8));
+        return new String(wire, StandardCharsets.UTF_8);
+    }
+
+    // =========================================================================
+    // User-defined message properties
+    // =========================================================================
+
+    @Test
+    public void userDefinedStringProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setStringProperty("strProp", "hello");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "strProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"hello\"}");
+    }
+
+    @Test
+    public void userDefinedIntProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setIntProperty("intProp", 42);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "intProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":42}");
+    }
+
+    @Test
+    public void userDefinedLongProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setLongProperty("longProp", 123456789012345L);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "longProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"int64\",\"optional\":false},\"payload\":123456789012345}");
+    }
+
+    @Test
+    public void userDefinedFloatProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setFloatProperty("floatProp", 1.5f);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "floatProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"float\",\"optional\":false},\"payload\":1.5}");
+    }
+
+    @Test
+    public void userDefinedDoubleProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setDoubleProperty("doubleProp", 3.141592653589793);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "doubleProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"double\",\"optional\":false},\"payload\":3.141592653589793}");
+    }
+
+    @Test
+    public void userDefinedBooleanProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setBooleanProperty("boolProp", true);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "boolProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"boolean\",\"optional\":false},\"payload\":true}");
+    }
+
+    @Test
+    public void userDefinedByteProperty() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setByteProperty("byteProp", (byte) 64);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "byteProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"int8\",\"optional\":false},\"payload\":64}");
+    }
+
+    @Test
+    public void userDefinedShortProperty_schemaIsInt16() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setShortProperty("shortProp", (short) 1000);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, "shortProp")).isEqualTo(
+            "{\"schema\":{\"type\":\"int16\",\"optional\":false},\"payload\":1000}");
+    }
+
+
+    // =========================================================================
+    // JMSx properties (standard JMS) 
+    // =========================================================================
+
+    @Test
+    public void jmsxDeliveryCount() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_DELIVERY_COUNT)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":1}");
+    }
+
+    @Test
+    public void jmsxUserId() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_USERID)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"app         \"}");
+    }
+
+    @Test
+    public void jmsxGroupId() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setStringProperty(JmsConstants.JMSX_GROUPID, "MY_GROUP");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_GROUPID)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"MY_GROUP\"}");
+    }
+
+    @Test
+    public void jmsxGroupSeq() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setIntProperty(JmsConstants.JMSX_GROUPSEQ, 3);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMSX_GROUPSEQ)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":3}");
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_* extension properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmFormat() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_FORMAT)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"MQSTR   \"}");
+    }
+
+    @Test
+    public void jmsIbmMsgType() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        // a normal datagram sent without a reply-to destination has a type of 8 (MQMT_DATAGRAM)
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MSGTYPE)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":8}");
+    }
+
+    @Test
+    public void jmsIbmCharacterSet() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_CHARACTER_SET)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"UTF-8\"}");
+    }
+
+    @Test
+    public void jmsIbmEncoding() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_ENCODING)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":273}");
+    }
+
+    @Test
+    public void jmsIbmPutDate() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+        final String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTDATE)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"" + today + "\"}");
+    }
+
+    @Test
+    public void jmsIbmPutTime() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTTIME))
+            .startsWith("{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"")
+            .endsWith("\"}");
+    }
+
+    @Test
+    public void jmsIbmPutApplType() throws Exception {
+        startTask(false);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_PUTAPPLTYPE))
+            .matches("\\{\"schema\":\\{\"type\":\"int32\",\"optional\":false\\},\"payload\":\\d+\\}");
+    }
+
+
+    // =========================================================================
+    // JMS_IBM_MQMD_* properties
+    // =========================================================================
+
+    @Test
+    public void jmsIbmMqmdPutApplName() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTAPPLNAME))
+            .startsWith("{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"")
+            .endsWith("\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdPutDate() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+        final String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTDATE)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"" + today + "\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdPutTime() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PUTTIME))
+            .startsWith("{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"")
+            .endsWith("\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdBackoutCount() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_BACKOUTCOUNT)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":0}");
+    }
+
+    @Test
+    public void jmsIbmMqmdPriority() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setJMSPriority(4);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PRIORITY)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":4}");
+    }
+
+    @Test
+    public void jmsIbmMqmdPersistence() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_PERSISTENCE)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":1}");
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgType() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_MSGTYPE)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":8}");
+    }
+
+    @Test
+    public void jmsIbmMqmdEncoding() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_ENCODING)).isEqualTo(
+            "{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":273}");
+    }
+
+    @Test
+    public void jmsIbmMqmdMsgId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        final String json = getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_MSGID);
+        assertThat(json)
+            .startsWith("{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"ID:")
+            .endsWith("\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdCorrelId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        message.setJMSCorrelationIDAsBytes(TEST_CORREL_ID);
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_CORRELID)).isEqualTo(
+            "{\"schema\":{\"type\":\"string\",\"optional\":false},\"payload\":\"ID:0102030405060708090a0b0c0d0e0f101112131415161718\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdAccountingToken() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_ACCOUNTINGTOKEN)).isEqualTo(
+            "{\"schema\":{\"type\":\"bytes\",\"optional\":false},\"payload\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"}");
+    }
+
+    @Test
+    public void jmsIbmMqmdGroupId() throws Exception {
+        startTask(true);
+        final TextMessage message = getJmsContext().createTextMessage("msg");
+        final Headers headers = pollHeaders(message);
+
+        assertThat(getHeaderAsJson(headers, JmsConstants.JMS_IBM_MQMD_GROUPID)).isEqualTo(
+            "{\"schema\":{\"type\":\"bytes\",\"optional\":false},\"payload\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}");
+    }
+}

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023, 2024, 2025 IBM Corporation
+ * Copyright 2022, 2023, 2024, 2025, 2026 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -434,6 +434,7 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         connectTask.commitRecord(kafkaMessage, null);
     }
+
     @Test
     public void verifyJmsMessageHeadersConvertedToString() throws Exception {
         // Test that JMS properties are converted to String (except byte[])
@@ -466,17 +467,17 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("teststring").schema().type());
         assertEquals("myvalue", kafkaMessage.headers().lastWithName("teststring").value());
         
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("volume").schema().type());
-        assertEquals("11", kafkaMessage.headers().lastWithName("volume").value());
+        assertEquals(Schema.Type.INT32, kafkaMessage.headers().lastWithName("volume").schema().type());
+        assertEquals(11, kafkaMessage.headers().lastWithName("volume").value());
         
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("decimalmeaning").schema().type());
-        assertEquals("42.0", kafkaMessage.headers().lastWithName("decimalmeaning").value());
+        assertEquals(Schema.Type.FLOAT64, kafkaMessage.headers().lastWithName("decimalmeaning").schema().type());
+        assertEquals(42.0, kafkaMessage.headers().lastWithName("decimalmeaning").value());
         
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("longvalue").schema().type());
-        assertEquals("123456789", kafkaMessage.headers().lastWithName("longvalue").value());
+        assertEquals(Schema.Type.INT64, kafkaMessage.headers().lastWithName("longvalue").schema().type());
+        assertEquals(123456789L, kafkaMessage.headers().lastWithName("longvalue").value());
         
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("flag").schema().type());
-        assertEquals("true", kafkaMessage.headers().lastWithName("flag").value());
+        assertEquals(Schema.Type.BOOLEAN, kafkaMessage.headers().lastWithName("flag").schema().type());
+        assertEquals(true, kafkaMessage.headers().lastWithName("flag").value());
 
         connectTask.commitRecord(kafkaMessage, null);
     }
@@ -512,8 +513,8 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("JMS_IBM_MQMD_MsgId").schema().type());
         
         // Custom integer property is also converted to String
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("volume").schema().type());
-        assertEquals("11", kafkaMessage.headers().lastWithName("volume").value());
+        assertEquals(Schema.Type.INT32, kafkaMessage.headers().lastWithName("volume").schema().type());
+        assertEquals(11, kafkaMessage.headers().lastWithName("volume").value());
 
         connectTask.commitRecord(kafkaMessage, null);
     }
@@ -546,11 +547,11 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         // Verify MQMD properties are present and converted to String
         // MQMD properties start with JMS_IBM_MQMD_ prefix
         assertNotNull(kafkaMessage.headers().lastWithName("JMS_IBM_MQMD_Priority"));
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("JMS_IBM_MQMD_Priority").schema().type());
+        assertEquals(Schema.Type.INT32, kafkaMessage.headers().lastWithName("JMS_IBM_MQMD_Priority").schema().type());
         
         // Custom property is also converted to String
-        assertEquals(Schema.Type.STRING, kafkaMessage.headers().lastWithName("customIntProp").schema().type());
-        assertEquals("999", kafkaMessage.headers().lastWithName("customIntProp").value());
+        assertEquals(Schema.Type.INT32, kafkaMessage.headers().lastWithName("customIntProp").schema().type());
+        assertEquals(999, kafkaMessage.headers().lastWithName("customIntProp").value());
 
         connectTask.commitRecord(kafkaMessage, null);
     }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, 2023, 2024, 2025, 2026 IBM Corporation
+ * Copyright 2022, 2023, 2024, 2025 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -429,8 +429,8 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         assertEquals("helloworld", kafkaMessage.value());
 
         assertEquals("myvalue", kafkaMessage.headers().lastWithName("teststring").value());
-        assertEquals("11", kafkaMessage.headers().lastWithName("volume").value());
-        assertEquals("42.0", kafkaMessage.headers().lastWithName("decimalmeaning").value());
+        assertEquals(11, kafkaMessage.headers().lastWithName("volume").value());
+        assertEquals(42.0, kafkaMessage.headers().lastWithName("decimalmeaning").value());
 
         connectTask.commitRecord(kafkaMessage, null);
     }
@@ -1270,8 +1270,8 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         // Actual headers
         assertThat(headers.lastWithName("teststring").value()).isEqualTo("myvalue");
-        assertThat(headers.lastWithName("volume").value()).isEqualTo("11");
-        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo("42.0");
+        assertThat(headers.lastWithName("volume").value()).isEqualTo(11);
+        assertThat(headers.lastWithName("decimalmeaning").value()).isEqualTo(42.0);
     }
 
     @Test
@@ -1304,9 +1304,9 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         // Verify JMS properties are copied to Kafka headers
         assertThat(headers.lastWithName("customHeader").value()).isEqualTo("headerValue");
-        assertThat(headers.lastWithName("priority").value()).isEqualTo("5");
-        assertThat(headers.lastWithName("price").value()).isEqualTo("99.99");
-        assertThat(headers.lastWithName("isActive").value()).isEqualTo("true");
+        assertThat(headers.lastWithName("priority").value()).isEqualTo(5);
+        assertThat(headers.lastWithName("price").value()).isEqualTo(99.99);
+        assertThat(headers.lastWithName("isActive").value()).isEqualTo(true);
     }
 
     @Test
@@ -1372,8 +1372,8 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         // Verify JMS properties are copied to Kafka headers
         assertThat(headers.lastWithName("correlationId").value()).isEqualTo("corr-123");
-        assertThat(headers.lastWithName("retryCount").value()).isEqualTo("3");
-        assertThat(headers.lastWithName("amount").value()).isEqualTo("150.75");
+        assertThat(headers.lastWithName("retryCount").value()).isEqualTo(3);
+        assertThat(headers.lastWithName("amount").value()).isEqualTo(150.75);
     }
 
     @Test
@@ -1435,15 +1435,15 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         final Headers headers = processedRecords.get(0).headers();
 
-        // Verify all property types are correctly converted to string headers
+        // Verify all property types are correctly converted to typed headers
         assertThat(headers.lastWithName("stringProp").value()).isEqualTo("text");
-        assertThat(headers.lastWithName("intProp").value()).isEqualTo("100");
-        assertThat(headers.lastWithName("longProp").value()).isEqualTo("999999999");
-        assertThat(headers.lastWithName("floatProp").value()).isEqualTo("3.14");
-        assertThat(headers.lastWithName("doubleProp").value()).isEqualTo("2.71828");
-        assertThat(headers.lastWithName("boolProp").value()).isEqualTo("false");
-        assertThat(headers.lastWithName("byteProp").value()).isEqualTo("127");
-        assertThat(headers.lastWithName("shortProp").value()).isEqualTo("32000");
+        assertThat(headers.lastWithName("intProp").value()).isEqualTo(100);
+        assertThat(headers.lastWithName("longProp").value()).isEqualTo(999999999L);
+        assertThat(headers.lastWithName("floatProp").value()).isEqualTo(3.14f);
+        assertThat(headers.lastWithName("doubleProp").value()).isEqualTo(2.71828);
+        assertThat(headers.lastWithName("boolProp").value()).isEqualTo(false);
+        assertThat(headers.lastWithName("byteProp").value()).isEqualTo((byte) 127);
+        assertThat(headers.lastWithName("shortProp").value()).isEqualTo((short) 32000);
     }
 
     @Test
@@ -1475,9 +1475,9 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
 
         // Verify all property types are correctly converted
         assertThat(headers.lastWithName("env").value()).isEqualTo("production");
-        assertThat(headers.lastWithName("maxRetries").value()).isEqualTo("5");
-        assertThat(headers.lastWithName("createdAt").value()).isEqualTo("1609459200000");
-        assertThat(headers.lastWithName("threshold").value()).isEqualTo("0.95");
-        assertThat(headers.lastWithName("enabled").value()).isEqualTo("true");
+        assertThat(headers.lastWithName("maxRetries").value()).isEqualTo(5);
+        assertThat(headers.lastWithName("createdAt").value()).isEqualTo(1609459200000L);
+        assertThat(headers.lastWithName("threshold").value()).isEqualTo(0.95);
+        assertThat(headers.lastWithName("enabled").value()).isEqualTo(true);
     }
 }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/builders/DefaultRecordBuilderIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/builders/DefaultRecordBuilderIT.java
@@ -210,8 +210,8 @@ public class DefaultRecordBuilderIT extends AbstractJMSContextIT {
             // Verify JMS properties are copied to Kafka headers
             Headers headers = sourceRecord.headers();
             assertThat(headers.lastWithName("customHeader").value()).isEqualTo("headerValue");
-            assertThat(headers.lastWithName("priority").value()).isEqualTo("5");
-            assertThat(headers.lastWithName("price").value()).isEqualTo("99.99");
+            assertThat(headers.lastWithName("priority").value()).isEqualTo(5);
+            assertThat(headers.lastWithName("price").value()).isEqualTo(99.99);
         } finally {
             worker.stop();
         }
@@ -258,8 +258,8 @@ public class DefaultRecordBuilderIT extends AbstractJMSContextIT {
             // Verify JMS properties are copied to Kafka headers
             Headers headers = sourceRecord.headers();
             assertThat(headers.lastWithName("messageType").value()).isEqualTo("binary");
-            assertThat(headers.lastWithName("version").value()).isEqualTo("2");
-            assertThat(headers.lastWithName("timestamp").value()).isEqualTo("1234567890");
+            assertThat(headers.lastWithName("version").value()).isEqualTo(2);
+            assertThat(headers.lastWithName("timestamp").value()).isEqualTo(1234567890L);
         } finally {
             worker.stop();
         }
@@ -305,9 +305,9 @@ public class DefaultRecordBuilderIT extends AbstractJMSContextIT {
             // Verify JMS properties are copied to Kafka headers
             Headers headers = sourceRecord.headers();
             assertThat(headers.lastWithName("source").value()).isEqualTo("system-a");
-            assertThat(headers.lastWithName("retryCount").value()).isEqualTo("3");
-            assertThat(headers.lastWithName("threshold").value()).isEqualTo("0.95");
-            assertThat(headers.lastWithName("enabled").value()).isEqualTo("true");
+            assertThat(headers.lastWithName("retryCount").value()).isEqualTo(3);
+            assertThat(headers.lastWithName("threshold").value()).isEqualTo(0.95);
+            assertThat(headers.lastWithName("enabled").value()).isEqualTo(true);
         } finally {
             worker.stop();
         }

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/builders/JsonRecordBuilderIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/builders/JsonRecordBuilderIT.java
@@ -202,9 +202,9 @@ public class JsonRecordBuilderIT extends AbstractJMSContextIT {
             // Verify JMS properties are copied to Kafka headers
             Headers headers = sourceRecord.headers();
             assertThat(headers.lastWithName("source").value()).isEqualTo("system-a");
-            assertThat(headers.lastWithName("retryCount").value()).isEqualTo("3");
-            assertThat(headers.lastWithName("threshold").value()).isEqualTo("0.95");
-            assertThat(headers.lastWithName("enabled").value()).isEqualTo("true");
+            assertThat(headers.lastWithName("retryCount").value()).isEqualTo(3);
+            assertThat(headers.lastWithName("threshold").value()).isEqualTo(0.95);
+            assertThat(headers.lastWithName("enabled").value()).isEqualTo(true);
         } finally {
             worker.stop();
         }

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/MQSourceConnector.java
@@ -243,7 +243,7 @@ public class MQSourceConnector extends SourceConnector {
         CONFIG_VALUE_MQ_CLIENT_RECONNECT_OPTION_DISABLED.toLowerCase(Locale.ENGLISH)
     };
 
-    public static String version = "2.8.1";
+    public static String version = "3.0.0";
 
     private Map<String, String> configProps;
 

--- a/src/main/java/com/ibm/eventstreams/connect/mqsource/processor/JmsToKafkaHeaderConverter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/mqsource/processor/JmsToKafkaHeaderConverter.java
@@ -76,11 +76,29 @@ public class JmsToKafkaHeaderConverter {
 
             log.debug("Adding JMS property {} with value {}", key, prop);
 
-            if (prop instanceof byte[]) {
+            if (prop == null) {
+                connectHeaders.addString(key, null);
+            } else if (prop instanceof byte[]) {
                 connectHeaders.addBytes(key, (byte[]) prop);
+            } else if (prop instanceof Byte) {
+                connectHeaders.addByte(key, (Byte) prop);
+            } else if (prop instanceof Short) {
+                connectHeaders.addShort(key, (Short) prop);
+            } else if (prop instanceof Integer) {
+                connectHeaders.addInt(key, (Integer) prop);
+            } else if (prop instanceof Long) {
+                connectHeaders.addLong(key, (Long) prop);
+            } else if (prop instanceof Float) {
+                connectHeaders.addFloat(key, (Float) prop);
+            } else if (prop instanceof Double) {
+                connectHeaders.addDouble(key, (Double) prop);
+            } else if (prop instanceof Boolean) {
+                connectHeaders.addBoolean(key, (Boolean) prop);
+            } else if (prop instanceof String) {
+                connectHeaders.addString(key, (String) prop);
             } else {
-                // this yields `null` if prop is null, otherwise its toString()
-                connectHeaders.addString(key, prop != null ? prop.toString() : null);
+                log.debug("Converting property '{}' of type '{}' to String", key, prop.getClass().getName());
+                connectHeaders.addString(key, prop.toString());
             }
         } catch (final JMSException e) {
             // Allow message processing to continue but log failure

--- a/src/test/java/com/ibm/eventstreams/connect/mqsource/JmsToKafkaHeaderConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/mqsource/JmsToKafkaHeaderConverterTest.java
@@ -63,12 +63,37 @@ public class JmsToKafkaHeaderConverterTest {
     }
 
     @Test
+    public void convertIntegerJmsPropertiesToKafkaHeaders() throws JMSException {
+        // Test that Integer JMS properties are stored as INT32 headers
+        final JmsToKafkaHeaderConverter converter = new JmsToKafkaHeaderConverter();
+
+        final List<String> keys = Arrays.asList("JMS_IBM_MQMD_Priority", "customIntProp");
+        final Enumeration<String> keyEnumeration = Collections.enumeration(keys);
+
+        // Arrange
+        when(message.getPropertyNames()).thenReturn(keyEnumeration);
+        when(message.getObjectProperty("JMS_IBM_MQMD_Priority")).thenReturn(5);
+        when(message.getObjectProperty("customIntProp")).thenReturn(12345);
+
+        // Act
+        final ConnectHeaders actualConnectHeaders = converter.convertJmsPropertiesToKafkaHeaders(message);
+
+        // Verify
+        assertEquals(2, actualConnectHeaders.size());
+
+        Header priorityHeader = actualConnectHeaders.lastWithName("JMS_IBM_MQMD_Priority");
+        assertEquals(Schema.Type.INT32, priorityHeader.schema().type());
+        assertEquals(5, priorityHeader.value());
+
+        Header customIntHeader = actualConnectHeaders.lastWithName("customIntProp");
+        assertEquals(Schema.Type.INT32, customIntHeader.schema().type());
+        assertEquals(12345, customIntHeader.value());
+    }
+
+    @Test
     public void convertMqmdByteArrayPropertiesToKafkaHeaders() throws JMSException {
         // Test that MQMD byte array properties are preserved as byte arrays.
         // Note: JMS spec does not allow custom byte[] properties - only MQMD properties can be byte[].
-        // Previously these were converted to their object reference string (e.g. "[B@5cde362e")
-        // which was not useful. This test verifies they are now stored as BYTES headers.
-
         final JmsToKafkaHeaderConverter converter = new JmsToKafkaHeaderConverter();
 
         final List<String> keys = Arrays.asList("JMS_IBM_MQMD_GroupId", "JMS_IBM_MQMD_AccountingToken");
@@ -124,51 +149,52 @@ public class JmsToKafkaHeaderConverterTest {
     }
 
     @Test
-    public void convertNumericJmsPropertiesToStringKafkaHeaders() throws JMSException {
-        // Test that numeric JMS properties are converted to their string representation.
-        // Integer 42 becomes the string "42", long 123456789L becomes "123456789", etc.
+    public void convertNumericAndPrimitiveJmsPropertiesToKafkaHeaders() throws JMSException {
+        // Test that all numeric and primitive JMS types are stored with their native schema types
         final JmsToKafkaHeaderConverter converter = new JmsToKafkaHeaderConverter();
 
-        final List<String> keys = Arrays.asList("intProp", "longProp", "floatProp",
-                                                  "doubleProp", "boolProp", "byteProp", "shortProp");
+        final List<String> keys = Arrays.asList("longProp", "shortProp", "byteProp",
+                                                  "booleanProp", "floatProp", "doubleProp");
         final Enumeration<String> keyEnumeration = Collections.enumeration(keys);
 
         // Arrange
         when(message.getPropertyNames()).thenReturn(keyEnumeration);
-        when(message.getObjectProperty("intProp")).thenReturn(42);
         when(message.getObjectProperty("longProp")).thenReturn(123456789L);
+        when(message.getObjectProperty("shortProp")).thenReturn((short) 100);
+        when(message.getObjectProperty("byteProp")).thenReturn((byte) 42);
+        when(message.getObjectProperty("booleanProp")).thenReturn(true);
         when(message.getObjectProperty("floatProp")).thenReturn(3.14f);
         when(message.getObjectProperty("doubleProp")).thenReturn(2.718281828);
-        when(message.getObjectProperty("boolProp")).thenReturn(true);
-        when(message.getObjectProperty("byteProp")).thenReturn((byte) 64);
-        when(message.getObjectProperty("shortProp")).thenReturn((short) 1000);
 
         // Act
         final ConnectHeaders actualConnectHeaders = converter.convertJmsPropertiesToKafkaHeaders(message);
 
-        // Verify: all non-byte-array types are stored as STRING headers
-        assertEquals(7, actualConnectHeaders.size());
+        // Verify: each type maps to its corresponding Connect schema type
+        assertEquals(6, actualConnectHeaders.size());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("intProp").schema().type());
-        assertEquals("42", actualConnectHeaders.lastWithName("intProp").value());
+        Header longHeader = actualConnectHeaders.lastWithName("longProp");
+        assertEquals(Schema.Type.INT64, longHeader.schema().type());
+        assertEquals(123456789L, longHeader.value());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("longProp").schema().type());
-        assertEquals("123456789", actualConnectHeaders.lastWithName("longProp").value());
+        Header shortHeader = actualConnectHeaders.lastWithName("shortProp");
+        assertEquals(Schema.Type.INT16, shortHeader.schema().type());
+        assertEquals((short) 100, shortHeader.value());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("floatProp").schema().type());
-        assertEquals("3.14", actualConnectHeaders.lastWithName("floatProp").value());
+        Header byteHeader = actualConnectHeaders.lastWithName("byteProp");
+        assertEquals(Schema.Type.INT8, byteHeader.schema().type());
+        assertEquals((byte) 42, byteHeader.value());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("doubleProp").schema().type());
-        assertEquals("2.718281828", actualConnectHeaders.lastWithName("doubleProp").value());
+        Header booleanHeader = actualConnectHeaders.lastWithName("booleanProp");
+        assertEquals(Schema.Type.BOOLEAN, booleanHeader.schema().type());
+        assertEquals(true, booleanHeader.value());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("boolProp").schema().type());
-        assertEquals("true", actualConnectHeaders.lastWithName("boolProp").value());
+        Header floatHeader = actualConnectHeaders.lastWithName("floatProp");
+        assertEquals(Schema.Type.FLOAT32, floatHeader.schema().type());
+        assertEquals(3.14f, floatHeader.value());
 
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("byteProp").schema().type());
-        assertEquals("64", actualConnectHeaders.lastWithName("byteProp").value());
-
-        assertEquals(Schema.Type.STRING, actualConnectHeaders.lastWithName("shortProp").schema().type());
-        assertEquals("1000", actualConnectHeaders.lastWithName("shortProp").value());
+        Header doubleHeader = actualConnectHeaders.lastWithName("doubleProp");
+        assertEquals(Schema.Type.FLOAT64, doubleHeader.schema().type());
+        assertEquals(2.718281828, doubleHeader.value());
     }
 
     @Test


### PR DESCRIPTION
# Description

JMS message properties were previously all converted to `String` when copied to Kafka headers (except for `byte[]` arrays which were already preserved). This meant that a JMS `Integer` property with value `42` would arrive in Kafka as the string `"42"`, losing type information and making downstream processing type-unaware.

This PR changes `JmsToKafkaHeaderConverter` to propagate the **native JMS property type** directly into the corresponding Kafka Connect header schema type:

| JMS property type | Kafka Connect schema type |
|---|---|
| `byte[]` | BYTES |
| `Byte` | INT8 |
| `Short` | INT16 |
| `Integer` | INT32 |
| `Long` | INT64 |
| `Float` | FLOAT32 |
| `Double` | FLOAT64 |
| `Boolean` | BOOLEAN |
| `String` | STRING |
| Anything else | STRING (via `toString()`) |

This is a **behavioural change** for consumers that rely on header values being strings — they will now receive typed values (e.g., `11` instead of `"11"` for an integer property).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
